### PR TITLE
Adding esp_adc_cal as extra component

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -20,6 +20,8 @@ conds:
         # https://esp-idf.readthedocs.io/en/latest/api-reference/peripherals/adc.html#adc-calibration
         - ["sys.esp32_adc_vref", "i", 0, {title: "ADC Vref, in mV"}]
         - ["sys.esp32_adc_width", "i", 3, {title: "ADC width, see ESP32 IDF"}]
+      build_vars:
+        ESP_IDF_EXTRA_COMPONENTS: ${build_vars.ESP_IDF_EXTRA_COMPONENTS} esp_adc_cal
 
 tags:
   - c


### PR DESCRIPTION
esp_adc_cal is needed to compile correctly. I've added it as an extra component when targetting esp32.